### PR TITLE
Story 1 Uniemożliwienie tworzenia kolidujących spotkań dla tych samych  użytkowników

### DIFF
--- a/src/main/java/pl/akademiaspecjalistowit/powtorzeniematerialu/app/MeetingApp.java
+++ b/src/main/java/pl/akademiaspecjalistowit/powtorzeniematerialu/app/MeetingApp.java
@@ -90,10 +90,7 @@ public class MeetingApp {
         while (!stop) {
             System.out.println("Podaj email uczestnika do zaprosznia: ");
             String emailNextPeople = scanner.nextLine();
-            boolean inAllMeetings = checkEmail(emailNextPeople, allMeetings);
-            if (inAllMeetings) {
-                throw new MeetingException("Ten email już jest w jednym ze spotkań. Nie ma możliwości dodać takie spotkanie.");
-            }
+
             participantEmail.add(emailNextPeople);
             System.out.println("Chcesz dodać więcej uczestników?: (T/N)");
             String decission = scanner.nextLine();
@@ -106,18 +103,6 @@ public class MeetingApp {
                 meetingService.createNewMeeting(meetingName, meetingDateTimeString, participantEmail, meetingDuration);
 
         System.out.println("Spotkanie " + newMeeting + " zostało utworzone.");
-    }
-
-    private boolean checkEmail(String emailNextPeople, List<Meeting> allMeetings) {
-        for (int i = 0; i < allMeetings.size(); i++) {
-            Set<String> nextMeeting = allMeetings.get(i).getParticipantEmail();
-            for (int j = 0; j < nextMeeting.size(); j++) {
-                if (nextMeeting.contains(emailNextPeople)) {
-                    return true;
-                }
-            }
-        }
-        return false;
     }
 
     private void deleteMeeting(Scanner scanner) {

--- a/src/main/java/pl/akademiaspecjalistowit/powtorzeniematerialu/app/MeetingApp.java
+++ b/src/main/java/pl/akademiaspecjalistowit/powtorzeniematerialu/app/MeetingApp.java
@@ -83,18 +83,14 @@ public class MeetingApp {
         System.out.println("Podaj długość trwania spotkania (w formacie HH:MM) ");
         String meetingDuration = scanner.nextLine();
 
-        List<Meeting> allMeetings = meetingService.getAllMeetings();
-
         Set<String> participantEmail = new HashSet<>();
         boolean stop = false;
         while (!stop) {
             System.out.println("Podaj email uczestnika do zaprosznia: ");
-            String emailNextPeople = scanner.nextLine();
-
-            participantEmail.add(emailNextPeople);
+            participantEmail.add(scanner.nextLine());
             System.out.println("Chcesz dodać więcej uczestników?: (T/N)");
             String decission = scanner.nextLine();
-            if (decission.equals("N")) {
+            if (decission.equals("N")||decission.equals("n")) {
                 stop = true;
             }
         }

--- a/src/main/java/pl/akademiaspecjalistowit/powtorzeniematerialu/app/MeetingApp.java
+++ b/src/main/java/pl/akademiaspecjalistowit/powtorzeniematerialu/app/MeetingApp.java
@@ -4,7 +4,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Scanner;
 import java.util.Set;
+
 import pl.akademiaspecjalistowit.powtorzeniematerialu.meeting.Meeting;
+import pl.akademiaspecjalistowit.powtorzeniematerialu.meeting.MeetingException;
 import pl.akademiaspecjalistowit.powtorzeniematerialu.meeting.MeetingService;
 
 public class MeetingApp {
@@ -81,11 +83,18 @@ public class MeetingApp {
         System.out.println("Podaj długość trwania spotkania (w formacie HH:MM) ");
         String meetingDuration = scanner.nextLine();
 
+        List<Meeting> allMeetings = meetingService.getAllMeetings();
+
         Set<String> participantEmail = new HashSet<>();
         boolean stop = false;
         while (!stop) {
             System.out.println("Podaj email uczestnika do zaprosznia: ");
-            participantEmail.add(scanner.nextLine());
+            String emailNextPeople = scanner.nextLine();
+            boolean inAllMeetings = checkEmail(emailNextPeople, allMeetings);
+            if (inAllMeetings) {
+                throw new MeetingException("Ten email już jest w jednym ze spotkań. Nie ma możliwości dodać takie spotkanie.");
+            }
+            participantEmail.add(emailNextPeople);
             System.out.println("Chcesz dodać więcej uczestników?: (T/N)");
             String decission = scanner.nextLine();
             if (decission.equals("N")) {
@@ -94,9 +103,21 @@ public class MeetingApp {
         }
 
         Meeting newMeeting =
-            meetingService.createNewMeeting(meetingName, meetingDateTimeString, participantEmail, meetingDuration);
+                meetingService.createNewMeeting(meetingName, meetingDateTimeString, participantEmail, meetingDuration);
 
         System.out.println("Spotkanie " + newMeeting + " zostało utworzone.");
+    }
+
+    private boolean checkEmail(String emailNextPeople, List<Meeting> allMeetings) {
+        for (int i = 0; i < allMeetings.size(); i++) {
+            Set<String> nextMeeting = allMeetings.get(i).getParticipantEmail();
+            for (int j = 0; j < nextMeeting.size(); j++) {
+                if (nextMeeting.contains(emailNextPeople)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     private void deleteMeeting(Scanner scanner) {

--- a/src/main/java/pl/akademiaspecjalistowit/powtorzeniematerialu/app/MeetingApp.java
+++ b/src/main/java/pl/akademiaspecjalistowit/powtorzeniematerialu/app/MeetingApp.java
@@ -90,7 +90,7 @@ public class MeetingApp {
             participantEmail.add(scanner.nextLine());
             System.out.println("Chcesz dodać więcej uczestników?: (T/N)");
             String decission = scanner.nextLine();
-            if (decission.equals("N")||decission.equals("n")) {
+            if (decission.toUpperCase().equals("N")) {
                 stop = true;
             }
         }

--- a/src/main/java/pl/akademiaspecjalistowit/powtorzeniematerialu/meeting/Meeting.java
+++ b/src/main/java/pl/akademiaspecjalistowit/powtorzeniematerialu/meeting/Meeting.java
@@ -80,4 +80,8 @@ public class Meeting {
     public int hashCode() {
         return Objects.hash(meetingId, name, dateAndTime, participantEmail, meetingDuration);
     }
+
+    public Set<String> getParticipantEmail() {
+        return participantEmail;
+    }
 }

--- a/src/main/java/pl/akademiaspecjalistowit/powtorzeniematerialu/meeting/Meeting.java
+++ b/src/main/java/pl/akademiaspecjalistowit/powtorzeniematerialu/meeting/Meeting.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
@@ -30,7 +31,7 @@ public class Meeting {
 
     }
 
-    private LocalDateTime parseStringToDate(String dateString) {
+    public LocalDateTime parseStringToDate(String dateString) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd:MM:yyyy HH:mm");
         try {
             return LocalDateTime.parse(dateString, formatter);
@@ -83,5 +84,13 @@ public class Meeting {
 
     public Set<String> getParticipantEmail() {
         return participantEmail;
+    }
+
+    public LocalDateTime getDateAndTime() {
+        return dateAndTime;
+    }
+
+    public Duration getMeetingDuration() {
+        return meetingDuration;
     }
 }

--- a/src/main/java/pl/akademiaspecjalistowit/powtorzeniematerialu/meeting/Meeting.java
+++ b/src/main/java/pl/akademiaspecjalistowit/powtorzeniematerialu/meeting/Meeting.java
@@ -31,7 +31,7 @@ public class Meeting {
 
     }
 
-    public LocalDateTime parseStringToDate(String dateString) {
+    public static LocalDateTime parseStringToDate(String dateString) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd:MM:yyyy HH:mm");
         try {
             return LocalDateTime.parse(dateString, formatter);
@@ -54,12 +54,12 @@ public class Meeting {
     @Override
     public String toString() {
         return "Meeting{" +
-            "meetingId=" + meetingId +
-            ", name='" + name + '\'' +
-            ", dateAndTime=" + dateAndTime +
-            ", participantEmail=" + participantEmail +
-            ", meetingDuration=" + meetingDuration +
-            '}';
+                "meetingId=" + meetingId +
+                ", name='" + name + '\'' +
+                ", dateAndTime=" + dateAndTime +
+                ", participantEmail=" + participantEmail +
+                ", meetingDuration=" + meetingDuration +
+                '}';
     }
 
     @Override
@@ -72,9 +72,9 @@ public class Meeting {
         }
         Meeting meeting = (Meeting) o;
         return Objects.equals(meetingId, meeting.meetingId) && Objects.equals(name, meeting.name) &&
-            Objects.equals(dateAndTime, meeting.dateAndTime) &&
-            Objects.equals(participantEmail, meeting.participantEmail) &&
-            Objects.equals(meetingDuration, meeting.meetingDuration);
+                Objects.equals(dateAndTime, meeting.dateAndTime) &&
+                Objects.equals(participantEmail, meeting.participantEmail) &&
+                Objects.equals(meetingDuration, meeting.meetingDuration);
     }
 
     @Override
@@ -92,5 +92,14 @@ public class Meeting {
 
     public Duration getMeetingDuration() {
         return meetingDuration;
+    }
+
+    public boolean checkEmailSetsForDuplicates(Meeting other) {
+        for (String email : this.getParticipantEmail()) {
+            if (other.getParticipantEmail().contains(email)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/pl/akademiaspecjalistowit/powtorzeniematerialu/meeting/Meeting.java
+++ b/src/main/java/pl/akademiaspecjalistowit/powtorzeniematerialu/meeting/Meeting.java
@@ -83,7 +83,7 @@ public class Meeting {
     }
 
     public Set<String> getParticipantEmail() {
-        return participantEmail;
+        return Set.copyOf(participantEmail);
     }
 
     public LocalDateTime getDateAndTime() {

--- a/src/main/java/pl/akademiaspecjalistowit/powtorzeniematerialu/meeting/Meeting.java
+++ b/src/main/java/pl/akademiaspecjalistowit/powtorzeniematerialu/meeting/Meeting.java
@@ -4,7 +4,6 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
-import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
@@ -31,7 +30,7 @@ public class Meeting {
 
     }
 
-    public static LocalDateTime parseStringToDate(String dateString) {
+    private static LocalDateTime parseStringToDate(String dateString) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd:MM:yyyy HH:mm");
         try {
             return LocalDateTime.parse(dateString, formatter);
@@ -40,7 +39,7 @@ public class Meeting {
         }
     }
 
-    public static Duration parseDurationFromString(String durationString) {
+    private static Duration parseDurationFromString(String durationString) {
         String[] parts = durationString.split(":");
         if (parts.length != 2) {
             throw new MeetingException("Nieprawidłowy format. Oczekiwano formatu HH:MM.");
@@ -94,12 +93,30 @@ public class Meeting {
         return meetingDuration;
     }
 
-    public boolean checkEmailSetsForDuplicates(Meeting other) {
+    private boolean emailHasMeetingOnThisTime(Meeting other) {
         for (String email : this.getParticipantEmail()) {
             if (other.getParticipantEmail().contains(email)) {
                 return true;
             }
         }
         return false;
+    }
+
+    private boolean overlapping_meetings(Meeting other) {
+        for (String email : this.getParticipantEmail()) {
+            LocalDateTime entThisMeeting = this.getDateAndTime().plus(getMeetingDuration());
+            if (other.getParticipantEmail().contains(email)) {
+                if ((this.getDateAndTime().compareTo(other.getDateAndTime()) == -1 &&
+                        entThisMeeting.compareTo(other.getDateAndTime()) == -1) ||
+                        (entThisMeeting.compareTo(other.getDateAndTime().plus(other.getMeetingDuration())) == 1 &&
+                                entThisMeeting.compareTo(other.getDateAndTime().plus(other.getMeetingDuration())) == 1))
+                    return false;
+            }
+        }
+        return true;
+    }
+
+    public boolean duplicateExist(Meeting other) {
+        return overlapping_meetings(other) && emailHasMeetingOnThisTime(other);
     }
 }

--- a/src/main/java/pl/akademiaspecjalistowit/powtorzeniematerialu/meeting/MeetingService.java
+++ b/src/main/java/pl/akademiaspecjalistowit/powtorzeniematerialu/meeting/MeetingService.java
@@ -1,5 +1,7 @@
 package pl.akademiaspecjalistowit.powtorzeniematerialu.meeting;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 
@@ -13,7 +15,11 @@ public class MeetingService {
 
     public Meeting createNewMeeting(String meetingName, String meetingDateTimeString, Set<String> participantEmail,
                                     String meetingDuration) {
-        Meeting meeting = new Meeting(meetingName,meetingDateTimeString, participantEmail, meetingDuration);
+        boolean inAllMeetings = checkEmail(participantEmail, meetingDateTimeString, meetingDuration);
+        if (inAllMeetings) {
+            throw new MeetingException("Ten email już jest w jednym ze spotkań. Nie ma możliwości dodać takie spotkanie.");
+        }
+        Meeting meeting = new Meeting(meetingName, meetingDateTimeString, participantEmail, meetingDuration);
         meetingRepository.save(meeting);
         return meeting;
     }
@@ -22,4 +28,26 @@ public class MeetingService {
     public List<Meeting> getAllMeetings() {
         return meetingRepository.findAll();
     }
+
+    private boolean checkEmail(Set<String> emailNextPeople, String meetingDateTimeString, String meetingDuration) {
+        List<Meeting> allMeetings = getAllMeetings();
+        for (int i = 0; i < allMeetings.size(); i++) {
+            Meeting nextMeeting = allMeetings.get(i);
+            Set<String> nextMeetingParticipants = nextMeeting.getParticipantEmail();
+            for (int j = 0; j < nextMeetingParticipants.size(); j++) {
+                LocalDateTime timeOfMeeting = nextMeeting.parseStringToDate(meetingDateTimeString);
+                Duration durationOfMeeting = Meeting.parseDurationFromString(meetingDuration);
+                if (nextMeetingParticipants.containsAll(emailNextPeople) &&
+                        (timeOfMeeting.compareTo(nextMeeting.getDateAndTime()) == 1 ||
+                                timeOfMeeting.compareTo(nextMeeting.getDateAndTime()) == 0) &&
+                        (timeOfMeeting.compareTo(nextMeeting.getDateAndTime().plus(nextMeeting.getMeetingDuration())) == -1)
+                ) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
 }
+
+

--- a/src/main/java/pl/akademiaspecjalistowit/powtorzeniematerialu/meeting/MeetingService.java
+++ b/src/main/java/pl/akademiaspecjalistowit/powtorzeniematerialu/meeting/MeetingService.java
@@ -17,7 +17,7 @@ public class MeetingService {
                                     String meetingDuration) {
 
         Meeting meeting = new Meeting(meetingName, meetingDateTimeString, participantEmail, meetingDuration);
-        boolean meetingsOverlap = checkEmail(participantEmail, meetingDateTimeString, meetingDuration, meeting);
+        boolean meetingsOverlap = participantHasMeeting(meeting);
         if (meetingsOverlap) {
             throw new MeetingException("Ten email już jest w jednym ze spotkań. Nie ma możliwości dodać takie spotkanie.");
         }
@@ -30,22 +30,13 @@ public class MeetingService {
         return meetingRepository.findAll();
     }
 
-    private boolean checkEmail(Set<String> newEmail, String newMeetingDateTimeString, String newMeetingDurationString, Meeting meeting) {
+    private boolean participantHasMeeting(Meeting meeting) {
         List<Meeting> allMeetings = getAllMeetings();
         for (int i = 0; i < allMeetings.size(); i++) {
-            Meeting nextMeeting = allMeetings.get(i);
-            Set<String> checkedListParticipantEmails = nextMeeting.getParticipantEmail();
+            Meeting otherMeeting = allMeetings.get(i);
+            Set<String> checkedListParticipantEmails = otherMeeting.getParticipantEmail();
             for (int j = 0; j < checkedListParticipantEmails.size(); j++) {
-                LocalDateTime startNewMeeting = Meeting.parseStringToDate(newMeetingDateTimeString);
-                Duration newMeetingDuration = Meeting.parseDurationFromString(newMeetingDurationString);
-                LocalDateTime endNewMeeting = startNewMeeting.plus(newMeetingDuration);
-                if (meeting.checkEmailSetsForDuplicates(nextMeeting)) {
-                    if ((startNewMeeting.compareTo(nextMeeting.getDateAndTime()) == -1 &&
-                            endNewMeeting.compareTo(nextMeeting.getDateAndTime()) == -1) ||
-                            (startNewMeeting.compareTo(nextMeeting.getDateAndTime().plus(nextMeeting.getMeetingDuration())) == 1 &&
-                                    endNewMeeting.compareTo(nextMeeting.getDateAndTime().plus(nextMeeting.getMeetingDuration())) == 1)) {
-                        return false;
-                    }
+                if (meeting.duplicateExist(otherMeeting)){
                     return true;
                 }
             }

--- a/src/test/java/pl/akademiaspecjalistowit/powtorzeniematerialu/meeting/MeetingServiceTest.java
+++ b/src/test/java/pl/akademiaspecjalistowit/powtorzeniematerialu/meeting/MeetingServiceTest.java
@@ -64,7 +64,7 @@ class MeetingServiceTest {
     }
 
     @Test
-    void making_overlapping_meetings_for_these_same_participants_is_possible() {
+    void making_overlapping_meetings_for_these_same_participants_is_inpossible() {
         // GIVEN
         String meetingName = "Test Meeting";
         String meetingDateTimeString = "01:01:2024 12:00";
@@ -94,7 +94,6 @@ class MeetingServiceTest {
         assertThat(allMeetings).hasSize(1);
     }
 
-
     @Test
     void making_overlapping_meetings_for_these_same_participants_is_inpossible_ending_meeting_later_start_previous() {
         // GIVEN
@@ -106,8 +105,8 @@ class MeetingServiceTest {
         Meeting first =
                 meetingService.createNewMeeting(meetingName, meetingDateTimeString, participantEmails, meetingDuration);
         String meetingNameSecond = "Test Meeting 2";
-        String meetingDateTimeStringSecond = "01:01:2024 12:10";
-        String meetingDurationSecond = "02:00";
+        String meetingDateTimeStringSecond = "01:01:2024 11:30";
+        String meetingDurationSecond = "01:00";
         // WHEN
         try {
             Meeting second =
@@ -117,6 +116,71 @@ class MeetingServiceTest {
         {
             assertThat(e.getMessage()).isNotEqualTo("");
         }
+    }
+
+    @Test
+    void making_overlapping_meetings_for_these_same_participants_is_inpossible_starting_meeting_before_start_previous_ending_after_previous() {
+        // GIVEN
+        String meetingName = "Test Meeting";
+        String meetingDateTimeString = "01:01:2024 12:00";
+        Set<String> participantEmails = new HashSet<>();
+        participantEmails.add("test@example.com");
+        String meetingDuration = "01:00";
+        Meeting first =
+                meetingService.createNewMeeting(meetingName, meetingDateTimeString, participantEmails, meetingDuration);
+        String meetingNameSecond = "Test Meeting 2";
+        String meetingDateTimeStringSecond = "01:01:2024 11:00";
+        String meetingDurationSecond = "03:00";
+        // WHEN
+        try {
+            Meeting second =
+                    meetingService.createNewMeeting(meetingNameSecond, meetingDateTimeStringSecond, participantEmails, meetingDurationSecond);
+        } catch (RuntimeException e)
+        // THEN
+        {
+            assertThat(e.getMessage()).isNotEqualTo("");
+        }
+    }
+
+    @Test
+    void making_overlapping_meetings_for_these_same_participants_is_possible_after_previous_meeting() {
+        // GIVEN
+        String meetingName = "Test Meeting";
+        String meetingDateTimeString = "01:01:2024 12:00";
+        Set<String> participantEmails = new HashSet<>();
+        participantEmails.add("test@example.com");
+        String meetingDuration = "01:00";
+        Meeting first =
+                meetingService.createNewMeeting(meetingName, meetingDateTimeString, participantEmails, meetingDuration);
+        String meetingNameSecond = "Test Meeting 2";
+        String meetingDateTimeStringSecond = "01:01:2024 13:10";
+        String meetingDurationSecond = "03:00";
+        // WHEN
+        Meeting second =
+                meetingService.createNewMeeting(meetingNameSecond, meetingDateTimeStringSecond, participantEmails, meetingDurationSecond);
+        // THEN
+        List<Meeting> allMeetings = meetingService.getAllMeetings();
+        assertThat(allMeetings).hasSize(2);
+    }
+    @Test
+    void making_overlapping_meetings_for_these_same_participants_is_possible_before_previous_meeting() {
+        // GIVEN
+        String meetingName = "Test Meeting";
+        String meetingDateTimeString = "01:01:2024 12:00";
+        Set<String> participantEmails = new HashSet<>();
+        participantEmails.add("test@example.com");
+        String meetingDuration = "01:00";
+        Meeting first =
+                meetingService.createNewMeeting(meetingName, meetingDateTimeString, participantEmails, meetingDuration);
+        String meetingNameSecond = "Test Meeting 2";
+        String meetingDateTimeStringSecond = "01:01:2024 10:00";
+        String meetingDurationSecond = "01:00";
+        // WHEN
+        Meeting second =
+                meetingService.createNewMeeting(meetingNameSecond, meetingDateTimeStringSecond, participantEmails, meetingDurationSecond);
+        // THEN
+        List<Meeting> allMeetings = meetingService.getAllMeetings();
+        assertThat(allMeetings).hasSize(2);
     }
 
 }

--- a/src/test/java/pl/akademiaspecjalistowit/powtorzeniematerialu/meeting/MeetingServiceTest.java
+++ b/src/test/java/pl/akademiaspecjalistowit/powtorzeniematerialu/meeting/MeetingServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Java6Assertions.assertThat;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -28,7 +29,7 @@ class MeetingServiceTest {
 
         // WHEN
         Meeting result =
-            meetingService.createNewMeeting(meetingName, meetingDateTimeString, participantEmails, meetingDuration);
+                meetingService.createNewMeeting(meetingName, meetingDateTimeString, participantEmails, meetingDuration);
 
         // THEN
         List<Meeting> allMeetings = meetingService.getAllMeetings();
@@ -43,7 +44,7 @@ class MeetingServiceTest {
         Set<String> participantEmails = Set.of("test123@example.com");
         String meetingDuration = "02:00";
         Meeting existingMeeting =
-            meetingService.createNewMeeting(meetingName, meetingDateTimeString, participantEmails, meetingDuration);
+                meetingService.createNewMeeting(meetingName, meetingDateTimeString, participantEmails, meetingDuration);
 
         String overlappingMeetingName = "Test Meeting";
         String overlappingMeetingDateTimeString = "01:01:2024 12:10";
@@ -52,10 +53,10 @@ class MeetingServiceTest {
 
         // WHEN
         Meeting overlappingMeeting = meetingService
-            .createNewMeeting(overlappingMeetingName,
-                overlappingMeetingDateTimeString,
-                overlappingParticipantEmails,
-                OverlappingMeetingDuration);
+                .createNewMeeting(overlappingMeetingName,
+                        overlappingMeetingDateTimeString,
+                        overlappingParticipantEmails,
+                        OverlappingMeetingDuration);
 
         // THEN
         List<Meeting> allMeetings = meetingService.getAllMeetings();
@@ -70,7 +71,7 @@ class MeetingServiceTest {
         Set<String> participantEmails = Set.of("test123@example.com");
         String meetingDuration = "02:00";
         Meeting existingMeeting =
-            meetingService.createNewMeeting(meetingName, meetingDateTimeString, participantEmails, meetingDuration);
+                meetingService.createNewMeeting(meetingName, meetingDateTimeString, participantEmails, meetingDuration);
 
         String overlappingMeetingName = "Test Meeting";
         String overlappingMeetingDateTimeString = "01:01:2024 12:10";
@@ -79,10 +80,10 @@ class MeetingServiceTest {
 
         // WHEN
         Meeting overlappingMeeting = meetingService
-            .createNewMeeting(overlappingMeetingName,
-                overlappingMeetingDateTimeString,
-                overlappingParticipantEmails,
-                OverlappingMeetingDuration);
+                .createNewMeeting(overlappingMeetingName,
+                        overlappingMeetingDateTimeString,
+                        overlappingParticipantEmails,
+                        OverlappingMeetingDuration);
 
         // THEN
         List<Meeting> allMeetings = meetingService.getAllMeetings();
@@ -113,6 +114,34 @@ class MeetingServiceTest {
         // THEN
         Meeting emptyMeeting = meetingService.getAllMeetings().get(1);
         assertThat(emptyMeeting.getParticipantEmail()).hasSize(0);
+    }
+
+    @Test
+    void making_overlapping_meetings_for_these_same_participants_is_inpossible() {
+        // GIVEN
+        String meetingName = "Test Meeting";
+        String meetingDateTimeString = "01:01:2024 12:00";
+        Set<String> participantEmails = new HashSet<>();
+        participantEmails.add("test@example.com");
+        String meetingDuration = "02:00";
+        Meeting first =
+                meetingService.createNewMeeting(meetingName, meetingDateTimeString, participantEmails, meetingDuration);
+        String meetingNameSecond = "Test Meeting 2";
+        String meetingDateTimeStringSecond = "01:01:2024 12:10";
+        String meetingDurationSecond = "02:00";
+        // WHEN
+        try {
+            Meeting second =
+                    meetingService.createNewMeeting(meetingNameSecond, meetingDateTimeStringSecond, participantEmails, meetingDurationSecond);
+        } catch (RuntimeException e)
+
+
+        // THEN
+        //List<Meeting> allMeetings = meetingService.getAllMeetings();
+        //assertThat(allMeetings).contains(result);
+        {
+            assertThat(e.getMessage()).isNotEqualTo("");
+        }
     }
 
 }

--- a/src/test/java/pl/akademiaspecjalistowit/powtorzeniematerialu/meeting/MeetingServiceTest.java
+++ b/src/test/java/pl/akademiaspecjalistowit/powtorzeniematerialu/meeting/MeetingServiceTest.java
@@ -89,5 +89,30 @@ class MeetingServiceTest {
         assertThat(allMeetings).hasSize(2);
     }
 
+    @Test
+    void create_meeting_whithout_repeat_email() {
+        // GIVEN
+        String meetingName = "Test Meeting";
+        String meetingDateTimeString = "01:01:2024 12:00";
+        Set<String> participantEmails = new HashSet<>();
+        participantEmails.add("test@example.com");
+        String meetingDuration = "02:00";
+        Meeting exist =
+                meetingService.createNewMeeting(meetingName, meetingDateTimeString, participantEmails, meetingDuration);
+
+        String meetingNameNext = "Test Meeting Next";
+        String meetingDateTimeStringNext = "01:03:2024 12:00";
+        Set<String> participantEmailsNext = new HashSet<>();
+        participantEmails.add("test@example.com");
+        String meetingDurationNext = "03:00";
+
+        // WHEN
+        Meeting result =
+                meetingService.createNewMeeting(meetingNameNext, meetingDateTimeStringNext, participantEmailsNext, meetingDurationNext);
+
+        // THEN
+        Meeting emptyMeeting = meetingService.getAllMeetings().get(1);
+        assertThat(emptyMeeting.getParticipantEmail()).hasSize(0);
+    }
 
 }

--- a/src/test/java/pl/akademiaspecjalistowit/powtorzeniematerialu/meeting/MeetingServiceTest.java
+++ b/src/test/java/pl/akademiaspecjalistowit/powtorzeniematerialu/meeting/MeetingServiceTest.java
@@ -94,19 +94,24 @@ class MeetingServiceTest {
         assertThat(allMeetings).hasSize(1);
     }
 
-    @Test
-    void making_overlapping_meetings_for_these_same_participants_is_inpossible_ending_meeting_later_start_previous() {
-        // GIVEN
+    private Meeting prepareValidMeeting() {
         String meetingName = "Test Meeting";
         String meetingDateTimeString = "01:01:2024 12:00";
         Set<String> participantEmails = new HashSet<>();
         participantEmails.add("test@example.com");
         String meetingDuration = "02:00";
-        Meeting first =
-                meetingService.createNewMeeting(meetingName, meetingDateTimeString, participantEmails, meetingDuration);
+        return meetingService.createNewMeeting(meetingName, meetingDateTimeString, participantEmails, meetingDuration);
+    }
+
+    @Test
+    void making_overlapping_meetings_for_these_same_participants_is_inpossible_ending_meeting_later_start_previous() {
+        // GIVEN
+        prepareValidMeeting();
         String meetingNameSecond = "Test Meeting 2";
         String meetingDateTimeStringSecond = "01:01:2024 11:30";
         String meetingDurationSecond = "01:00";
+        Set<String> participantEmails = new HashSet<>();
+        participantEmails.add("test@example.com");
         // WHEN
         try {
             Meeting second =
@@ -121,13 +126,9 @@ class MeetingServiceTest {
     @Test
     void making_overlapping_meetings_for_these_same_participants_is_inpossible_starting_meeting_before_start_previous_ending_after_previous() {
         // GIVEN
-        String meetingName = "Test Meeting";
-        String meetingDateTimeString = "01:01:2024 12:00";
+        prepareValidMeeting();
         Set<String> participantEmails = new HashSet<>();
         participantEmails.add("test@example.com");
-        String meetingDuration = "01:00";
-        Meeting first =
-                meetingService.createNewMeeting(meetingName, meetingDateTimeString, participantEmails, meetingDuration);
         String meetingNameSecond = "Test Meeting 2";
         String meetingDateTimeStringSecond = "01:01:2024 11:00";
         String meetingDurationSecond = "03:00";
@@ -145,13 +146,9 @@ class MeetingServiceTest {
     @Test
     void making_overlapping_meetings_for_these_same_participants_is_possible_after_previous_meeting() {
         // GIVEN
-        String meetingName = "Test Meeting";
-        String meetingDateTimeString = "01:01:2024 12:00";
+        prepareValidMeeting();
         Set<String> participantEmails = new HashSet<>();
         participantEmails.add("test@example.com");
-        String meetingDuration = "01:00";
-        Meeting first =
-                meetingService.createNewMeeting(meetingName, meetingDateTimeString, participantEmails, meetingDuration);
         String meetingNameSecond = "Test Meeting 2";
         String meetingDateTimeStringSecond = "01:01:2024 13:10";
         String meetingDurationSecond = "03:00";
@@ -162,16 +159,13 @@ class MeetingServiceTest {
         List<Meeting> allMeetings = meetingService.getAllMeetings();
         assertThat(allMeetings).hasSize(2);
     }
+
     @Test
     void making_overlapping_meetings_for_these_same_participants_is_possible_before_previous_meeting() {
         // GIVEN
-        String meetingName = "Test Meeting";
-        String meetingDateTimeString = "01:01:2024 12:00";
+        prepareValidMeeting();
         Set<String> participantEmails = new HashSet<>();
         participantEmails.add("test@example.com");
-        String meetingDuration = "01:00";
-        Meeting first =
-                meetingService.createNewMeeting(meetingName, meetingDateTimeString, participantEmails, meetingDuration);
         String meetingNameSecond = "Test Meeting 2";
         String meetingDateTimeStringSecond = "01:01:2024 10:00";
         String meetingDurationSecond = "01:00";

--- a/src/test/java/pl/akademiaspecjalistowit/powtorzeniematerialu/meeting/MeetingServiceTest.java
+++ b/src/test/java/pl/akademiaspecjalistowit/powtorzeniematerialu/meeting/MeetingServiceTest.java
@@ -79,45 +79,24 @@ class MeetingServiceTest {
         String OverlappingMeetingDuration = "01:00";
 
         // WHEN
-        Meeting overlappingMeeting = meetingService
-                .createNewMeeting(overlappingMeetingName,
-                        overlappingMeetingDateTimeString,
-                        overlappingParticipantEmails,
-                        OverlappingMeetingDuration);
+        try {
+            Meeting overlappingMeeting = meetingService
+                    .createNewMeeting(overlappingMeetingName,
+                            overlappingMeetingDateTimeString,
+                            overlappingParticipantEmails,
+                            OverlappingMeetingDuration);
+        } catch (RuntimeException e) {
+            assertThat(e.getMessage()).isNotEqualTo("");
+        }
 
         // THEN
         List<Meeting> allMeetings = meetingService.getAllMeetings();
-        assertThat(allMeetings).hasSize(2);
+        assertThat(allMeetings).hasSize(1);
     }
 
-    @Test
-    void create_meeting_whithout_repeat_email() {
-        // GIVEN
-        String meetingName = "Test Meeting";
-        String meetingDateTimeString = "01:01:2024 12:00";
-        Set<String> participantEmails = new HashSet<>();
-        participantEmails.add("test@example.com");
-        String meetingDuration = "02:00";
-        Meeting exist =
-                meetingService.createNewMeeting(meetingName, meetingDateTimeString, participantEmails, meetingDuration);
-
-        String meetingNameNext = "Test Meeting Next";
-        String meetingDateTimeStringNext = "01:03:2024 12:00";
-        Set<String> participantEmailsNext = new HashSet<>();
-        participantEmails.add("test@example.com");
-        String meetingDurationNext = "03:00";
-
-        // WHEN
-        Meeting result =
-                meetingService.createNewMeeting(meetingNameNext, meetingDateTimeStringNext, participantEmailsNext, meetingDurationNext);
-
-        // THEN
-        Meeting emptyMeeting = meetingService.getAllMeetings().get(1);
-        assertThat(emptyMeeting.getParticipantEmail()).hasSize(0);
-    }
 
     @Test
-    void making_overlapping_meetings_for_these_same_participants_is_inpossible() {
+    void making_overlapping_meetings_for_these_same_participants_is_inpossible_ending_meeting_later_start_previous() {
         // GIVEN
         String meetingName = "Test Meeting";
         String meetingDateTimeString = "01:01:2024 12:00";
@@ -134,11 +113,7 @@ class MeetingServiceTest {
             Meeting second =
                     meetingService.createNewMeeting(meetingNameSecond, meetingDateTimeStringSecond, participantEmails, meetingDurationSecond);
         } catch (RuntimeException e)
-
-
         // THEN
-        //List<Meeting> allMeetings = meetingService.getAllMeetings();
-        //assertThat(allMeetings).contains(result);
         {
             assertThat(e.getMessage()).isNotEqualTo("");
         }


### PR DESCRIPTION
Obecnie tworzenie spotkań nie posiada żadnych restrykcji. Należy 
uniemożliwić stworzenie spotkania dla danego adresu email, jeżeli jest ono 
“na zakładkę” z zapisanym już spotkaniem.