### PR TITLE
Story-2 Dodawanie możliwości usuwania spotkań po numerze spotkania

### DIFF
--- a/src/main/java/pl/akademiaspecjalistowit/powtorzeniematerialu/app/MeetingApp.java
+++ b/src/main/java/pl/akademiaspecjalistowit/powtorzeniematerialu/app/MeetingApp.java
@@ -4,7 +4,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Scanner;
 import java.util.Set;
+
 import pl.akademiaspecjalistowit.powtorzeniematerialu.meeting.Meeting;
+import pl.akademiaspecjalistowit.powtorzeniematerialu.meeting.MeetingException;
 import pl.akademiaspecjalistowit.powtorzeniematerialu.meeting.MeetingService;
 
 public class MeetingApp {
@@ -65,8 +67,8 @@ public class MeetingApp {
             System.out.println("Brak spotkań");
             return;
         }
-        for (Meeting meeting : allMeetings) {
-            System.out.println(meeting);
+        for (int i = 0; i < allMeetings.size(); i++) {
+            System.out.println("№ " + (i + 1) + " - " + allMeetings.get(i));
         }
     }
 
@@ -94,13 +96,24 @@ public class MeetingApp {
         }
 
         Meeting newMeeting =
-            meetingService.createNewMeeting(meetingName, meetingDateTimeString, participantEmail, meetingDuration);
+                meetingService.createNewMeeting(meetingName, meetingDateTimeString, participantEmail, meetingDuration);
 
         System.out.println("Spotkanie " + newMeeting + " zostało utworzone.");
     }
 
     private void deleteMeeting(Scanner scanner) {
-        System.out.println("Usuwanie spotkań nie zostało jeszcze zaimplementowane");
+        showMeetings();
+        if (meetingService.getAllMeetings().size()==0){
+            return;
+        }
+        System.out.println("Podaj numer spotkania zgodnie z listą: ");
+        String meetingId = scanner.nextLine();
+        try {
+            meetingService.removeMeeting(Long.parseLong(meetingId) - 1);
+            System.out.println("Spotkanie z numerem " + meetingId + " zostało usunięte!");
+        } catch (MeetingException e) {
+            System.out.println(e.getMessage());
+        }
     }
 
 }

--- a/src/main/java/pl/akademiaspecjalistowit/powtorzeniematerialu/meeting/MeetingRepository.java
+++ b/src/main/java/pl/akademiaspecjalistowit/powtorzeniematerialu/meeting/MeetingRepository.java
@@ -19,4 +19,12 @@ public class MeetingRepository {
     public List<Meeting> findAll() {
         return meetings.values().stream().toList();
     }
+
+    public Meeting remove(Long id) {
+        try {
+            return meetings.remove(id);
+        } catch (RuntimeException e) {
+            throw new MeetingException("Coś poszło nie tak...");
+        }
+    }
 }

--- a/src/main/java/pl/akademiaspecjalistowit/powtorzeniematerialu/meeting/MeetingService.java
+++ b/src/main/java/pl/akademiaspecjalistowit/powtorzeniematerialu/meeting/MeetingService.java
@@ -22,4 +22,8 @@ public class MeetingService {
     public List<Meeting> getAllMeetings() {
         return meetingRepository.findAll();
     }
+
+    public Meeting removeMeeting(Long id) {
+        return meetingRepository.remove(id);
+    }
 }

--- a/src/test/java/pl/akademiaspecjalistowit/powtorzeniematerialu/meeting/MeetingServiceTest.java
+++ b/src/test/java/pl/akademiaspecjalistowit/powtorzeniematerialu/meeting/MeetingServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Java6Assertions.assertThat;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -28,7 +29,7 @@ class MeetingServiceTest {
 
         // WHEN
         Meeting result =
-            meetingService.createNewMeeting(meetingName, meetingDateTimeString, participantEmails, meetingDuration);
+                meetingService.createNewMeeting(meetingName, meetingDateTimeString, participantEmails, meetingDuration);
 
         // THEN
         List<Meeting> allMeetings = meetingService.getAllMeetings();
@@ -43,7 +44,7 @@ class MeetingServiceTest {
         Set<String> participantEmails = Set.of("test123@example.com");
         String meetingDuration = "02:00";
         Meeting existingMeeting =
-            meetingService.createNewMeeting(meetingName, meetingDateTimeString, participantEmails, meetingDuration);
+                meetingService.createNewMeeting(meetingName, meetingDateTimeString, participantEmails, meetingDuration);
 
         String overlappingMeetingName = "Test Meeting";
         String overlappingMeetingDateTimeString = "01:01:2024 12:10";
@@ -52,10 +53,10 @@ class MeetingServiceTest {
 
         // WHEN
         Meeting overlappingMeeting = meetingService
-            .createNewMeeting(overlappingMeetingName,
-                overlappingMeetingDateTimeString,
-                overlappingParticipantEmails,
-                OverlappingMeetingDuration);
+                .createNewMeeting(overlappingMeetingName,
+                        overlappingMeetingDateTimeString,
+                        overlappingParticipantEmails,
+                        OverlappingMeetingDuration);
 
         // THEN
         List<Meeting> allMeetings = meetingService.getAllMeetings();
@@ -70,7 +71,7 @@ class MeetingServiceTest {
         Set<String> participantEmails = Set.of("test123@example.com");
         String meetingDuration = "02:00";
         Meeting existingMeeting =
-            meetingService.createNewMeeting(meetingName, meetingDateTimeString, participantEmails, meetingDuration);
+                meetingService.createNewMeeting(meetingName, meetingDateTimeString, participantEmails, meetingDuration);
 
         String overlappingMeetingName = "Test Meeting";
         String overlappingMeetingDateTimeString = "01:01:2024 12:10";
@@ -79,15 +80,64 @@ class MeetingServiceTest {
 
         // WHEN
         Meeting overlappingMeeting = meetingService
-            .createNewMeeting(overlappingMeetingName,
-                overlappingMeetingDateTimeString,
-                overlappingParticipantEmails,
-                OverlappingMeetingDuration);
+                .createNewMeeting(overlappingMeetingName,
+                        overlappingMeetingDateTimeString,
+                        overlappingParticipantEmails,
+                        OverlappingMeetingDuration);
 
         // THEN
         List<Meeting> allMeetings = meetingService.getAllMeetings();
         assertThat(allMeetings).hasSize(2);
     }
 
+    @Test
+    void deletion_meeting_successful() {
+        // GIVEN
+        String meetingName = "Test Meeting";
+        String meetingDateTimeString = "01:01:2024 12:00";
+        Set<String> participantEmails = Set.of("test123@example.com");
+        String meetingDuration = "02:00";
+        Meeting firstMeeting =
+                meetingService.createNewMeeting(meetingName, meetingDateTimeString, participantEmails, meetingDuration);
 
+        String overlappingMeetingName = "Test Meeting";
+        String overlappingMeetingDateTimeString = "01:01:2024 12:10";
+        Set<String> overlappingParticipantEmails = Set.of("test1234@example.com");
+        String OverlappingMeetingDuration = "01:00";
+        Meeting secondMeeting = meetingService
+                .createNewMeeting(overlappingMeetingName,
+                        overlappingMeetingDateTimeString,
+                        overlappingParticipantEmails,
+                        OverlappingMeetingDuration);
+
+        // WHEN
+        Meeting remotedMeeting = meetingService.removeMeeting(1l);
+
+        // THEN
+        List<Meeting> allMeetings = meetingService.getAllMeetings();
+        assertThat(allMeetings).hasSize(1);
+        assertThat(allMeetings.get(0)).isEqualTo(firstMeeting);
+    }
+
+    @Test
+    void deletion_meeting_failure() {
+        // GIVEN
+        String meetingName = "Test Meeting";
+        String meetingDateTimeString = "01:01:2024 12:00";
+        Set<String> participantEmails = Set.of("test123@example.com");
+        String meetingDuration = "02:00";
+        Meeting firstMeeting =
+                meetingService.createNewMeeting(meetingName, meetingDateTimeString, participantEmails, meetingDuration);
+
+        // WHEN
+        try {
+            Meeting remotedMeeting = meetingService.removeMeeting(1l);
+        } catch (MeetingException e) {
+            // THEN
+            List<Meeting> allMeetings = meetingService.getAllMeetings();
+            assertThat(allMeetings).hasSize(1);
+            assertThat(allMeetings.get(0)).isEqualTo(firstMeeting);
+            assertThat(e.getMessage()).isEqualTo("Coś poszło nie tak...");
+        }
+    }
 }


### PR DESCRIPTION
Opis zadania:
Uniemożliwienie usuwania spotkań po identyfikatorze spotkania.
Obecnie funkcjonalność usuwania spotkań nie została zaimplementowana 
w systemie. Należy umożliwić użytkownikowi aplikacji usunięcie 
wskazanego spotkania.

!!! Zgodnie z tym, że id spotkania jest bardzo długi, i użytkownik może zrobić bląd, wprowadzjąc go, realizowałam możliwość usuwania spotkania zgodnie z numerem w liście spotkań, ktora jest pokazana użytkowniku przed usuwaniem